### PR TITLE
Updated policy file to disable more tracking and features

### DIFF
--- a/root/etc/brave/policies/managed/policy.json
+++ b/root/etc/brave/policies/managed/policy.json
@@ -2,7 +2,17 @@
     "BraveRewardsDisabled": true,
     "BraveWalletDisabled": true,
     "BraveVPNDisabled": true,
+    "BraveAIChatEnabled": false,
+    "BraveStatsPingEnabled": false,
+    "BraveWebDiscoveryEnabled": false,
+    "BraveNewsDisabled": true,
+    "BraveTalkDisabled": true,
+    "BravePlaylistEnabled": false,
     "PromotionsEnabled": false,
     "DefaultBrowserSettingEnabled": false,
-    "FeedbackSurveysEnabled": false
+    "FeedbackSurveysEnabled": false,
+    "BraveP3AEnabled": false,
+    "UrlKeyedAnonymizedDataCollectionEnabled": false,
+    "SafeBrowsingExtendedReportingEnabled": false,
+    "MetricsReportingEnabled": false
 }


### PR DESCRIPTION
This pull request updates the `policy.json` configuration to further restrict various Brave browser features and enhance privacy by disabling additional services and data collection options.

Policy and privacy settings:

* Disabled Brave AI Chat, Brave Stats Ping, Brave Web Discovery, and Brave Playlist features by setting their enabled flags to `false`.
* Disabled Brave News and Brave Talk features by setting their disabled flags to `true`.

Telemetry and data collection:

* Disabled Brave P3A, URL-keyed anonymized data collection, Safe Browsing extended reporting, and general metrics reporting to further limit telemetry and data collection.