### PR TITLE
Pin brave package version for install

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,6 +26,7 @@ jobs:
     outputs:
       brave_package_version: ${{ steps.version.outputs.brave_package_version }}
       keyring_package_version: ${{ steps.version.outputs.keyring_package_version }}
+      image_tag: ${{ steps.version.outputs.image_tag }}
     steps:
       - name: Add Brave's APT repository
         run: |

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -43,6 +43,7 @@ jobs:
           keyring_package_version=$(apt-cache policy brave-keyring | awk -F': ' '/Candidate:/ {print $2}')
           [ -n "$brave_package_version" ] || { echo "Failed to determine Brave package version" >&2; exit 1; }
           [ -n "$keyring_package_version" ] || { echo "Failed to determine Brave keyring package version" >&2; exit 1; }
+          image_tag=$(echo "$brave_package_version" | cut -d'~' -f1 | sed -E 's/^[0-9]+://; s/[^0-9A-Za-z_.-]+/-/g')
           echo "brave_package_version=$brave_package_version" >> $GITHUB_OUTPUT
           echo "keyring_package_version=$keyring_package_version" >> $GITHUB_OUTPUT
           echo "image_tag=$image_tag" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,10 +21,11 @@ jobs:
           echo "date=$(date --rfc-3339=seconds | sed 's/ /T/')" >> $GITHUB_OUTPUT
 
   version:
-    name: Get latest package version
+    name: Determine package version
     runs-on: ubuntu-latest
     outputs:
-      package_version: ${{ steps.version.outputs.package_version }}
+      brave_package_version: ${{ steps.version.outputs.brave_package_version }}
+      keyring_package_version: ${{ steps.version.outputs.keyring_package_version }}
     steps:
       - name: Add Brave's APT repository
         run: |
@@ -34,12 +35,19 @@ jobs:
             sudo tee -a /etc/apt/sources.list.d/brave-browser-release.list
           sudo apt-get update -y
 
-      - name: Get package version
+      - name: Get package versions and set image tag
         id: version
         run: |
-          package_version=$(apt list brave-browser | awk -F'[ /]' '/brave-browser/ {print $3}')
-          echo "package_version=${package_version}" >> $GITHUB_OUTPUT
-          echo "The package version is $package_version"
+          brave_package_version=$(apt-cache policy brave-browser | awk -F': ' '/Candidate:/ {print $2}')
+          keyring_package_version=$(apt-cache policy brave-keyring | awk -F': ' '/Candidate:/ {print $2}')
+          [ -n "$brave_package_version" ] || { echo "Failed to determine Brave package version" >&2; exit 1; }
+          [ -n "$keyring_package_version" ] || { echo "Failed to determine Brave keyring package version" >&2; exit 1; }
+          echo "brave_package_version=$brave_package_version" >> $GITHUB_OUTPUT
+          echo "keyring_package_version=$keyring_package_version" >> $GITHUB_OUTPUT
+          echo "image_tag=$image_tag" >> $GITHUB_OUTPUT
+          echo "Brave Browser Package Version: $brave_package_version"
+          echo "Brave Keyring Package Version: $keyring_package_version"
+          echo "Image Tag: $image_tag"
 
   build:
     name: Build and push image
@@ -76,13 +84,15 @@ jobs:
           file: ./Dockerfile
           push: true
           build-args: |
-            IMAGE_BUILD_DATE=IMAGE_BUILD_DATE=${{ needs.date.outputs.date }}
+            IMAGE_BUILD_DATE=${{ needs.date.outputs.date }}
+            BROWSER_INSTALL_VERSION=${{ needs.version.outputs.brave_package_version }}
+            KEYRING_INSTALL_VERSION=${{ needs.version.outputs.keyring_package_version }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/brave:latest
-            ghcr.io/${{ github.repository_owner }}/brave:${{ needs.version.outputs.package_version }}
+            ghcr.io/${{ github.repository_owner }}/brave:${{ needs.version.outputs.image_tag }}
             ${{ vars.DOCKERHUB_USERNAME }}/brave:latest
-            ${{ vars.DOCKERHUB_USERNAME }}/brave:${{ needs.version.outputs.package_version }}
+            ${{ vars.DOCKERHUB_USERNAME }}/brave:${{ needs.version.outputs.image_tag }}
           labels: |
             org.opencontainers.image.ref.name=${{ github.ref }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ needs.version.outputs.package_version }}
+            org.opencontainers.image.version=${{ needs.version.outputs.image_tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM ghcr.io/linuxserver/baseimage-kasmvnc:debianbookworm
 
 # set labels
 ARG IMAGE_BUILD_DATE
+ARG BROWSER_INSTALL_VERSION
+ARG KEYRING_INSTALL_VERSION
 LABEL release_channel="stable"
 LABEL org.opencontainers.image.authors="tibynx"
 LABEL org.opencontainers.image.created="${IMAGE_BUILD_DATE}"
@@ -34,8 +36,8 @@ RUN \
     > /etc/apt/sources.list.d/brave-browser-release.list && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
-    brave-keyring \
-    brave-browser && \
+    brave-keyring=${KEYRING_INSTALL_VERSION} \
+    brave-browser=${BROWSER_INSTALL_VERSION} && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \


### PR DESCRIPTION
This pull request updates the Docker image build workflow and `Dockerfile` to improve version control and reproducibility. It now explicitly determines and passes the exact versions of the `brave-browser` and `brave-keyring` packages to the Docker build, and uses a consistent, sanitized image tag based on the Brave package version.

**Workflow and Versioning Improvements:**

* The GitHub Actions workflow now fetches both the `brave-browser` and `brave-keyring` package versions, sets a sanitized `image_tag` for Docker images, and exposes these as outputs for later steps. [[1]](diffhunk://#diff-8b50c1c8ac07bc956388add66e256e8336ae22fd2cac8d83f770e1dc63674c00L24-R29) [[2]](diffhunk://#diff-8b50c1c8ac07bc956388add66e256e8336ae22fd2cac8d83f770e1dc63674c00L37-R52)
* The Docker build job now passes the determined package versions and build date as build arguments, and uses the new `image_tag` for all image tags and labels, ensuring consistency and traceability.

**Dockerfile Changes:**

* The `Dockerfile` now accepts `BROWSER_INSTALL_VERSION` and `KEYRING_INSTALL_VERSION` as build arguments, and installs the exact versions of `brave-browser` and `brave-keyring` specified, improving reproducibility. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R5-R6) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L37-R40)